### PR TITLE
Add ARM64 Suppot for Travis-Ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 sudo: required
-dist: xenial
+dist: focal
+group: edge
+virt: vm
+arch:
+- amd64
+- arm64-graviton2
+
 
 os: linux
 
@@ -106,7 +112,7 @@ install:
 
 script:
   - util/mirror-tarballs > build.log 2>&1 || (cat build.log && exit 1)
-  - cd openresty-*
+  - cd openresty-1.19.3.1
   - ./configure --prefix=$OPENRESTY_PREFIX --with-cc-opt="-I$PCRE_INC -I$OPENSSL_INC" --with-ld-opt="-L$PCRE_LIB -L$OPENSSL_LIB -Wl,-rpath,$PCRE_LIB:$OPENSSL_LIB" --with-pcre-jit --with-http_ssl_module --with-debug -j$JOBS > build.log 2>&1 || (cat build.log && exit 1)
   - make -j$JOBS > build.log 2>&1 || (cat build.log && exit 1)
   - sudo make install > build.log 2>&1 || (cat build.log && exit 1)


### PR DESCRIPTION
Hi,

Package Owner: Mohneesh Jha
PR change Details:

#Patch Details : .travis.yml have been modified 

.travis.yml : arm64-graviton tag has been added  for travis-testing

#Testing Detail :
The testing is done over travis

#Reviewer Comment : < To be filled by Reviewer >

#PR Description :
Here is my commit message : Added ARM64 job in Travis-CI

Body of PR :

Added ARM64-graviton job in Travis-CI.

Signed-off-by: odidev@puresoftware.com.

#Reviewer: Pruthvi Teja

Thanks,
Mohneesh Jha